### PR TITLE
changed filter ref frame to base_footprint

### DIFF
--- a/calvin_bringup/launch/xtion_filter_chain.launch
+++ b/calvin_bringup/launch/xtion_filter_chain.launch
@@ -33,8 +33,8 @@
     <remap from="~input" to="/kinect/depth_registered/points_filtered" />
     <remap from="~output" to="/kinect/depth_registered/points_filtered_cut_floor" />
     <rosparam>
-      input_frame: map
-      output_frame: map
+      input_frame: base_footprint
+      output_frame: base_footprint
       filter_field_name: z
       filter_limit_min: 0.05
       filter_limit_max: 2.0


### PR DESCRIPTION
if we transform the cloud to map we a) rely on having a transformation between robot and map and b) run into problems when tf is slow, which sometimes lead to errors during filtering
