### PR TITLE
fix sick_lms200 parameters

### DIFF
--- a/calvin_bringup/launch/sick_lms200.launch
+++ b/calvin_bringup/launch/sick_lms200.launch
@@ -4,6 +4,7 @@
     <remap from="scan" to="lms200" />
     <param name="port" value="/dev/scanner" />
     <param name="baud" value="500000" />
+    <param name="angle" value="180" />
     <param name="resolution" value="1.0" />
     <param name="frame_id" value="/sick_lms200" />
   </node>


### PR DESCRIPTION
The driver produces warnings about an unusable angle value (default 0) and an
unusable resolution value. It seems the driver always used .5 after it failed
to set the specified value of 1 (maybe only starting with hydro/indigo?)
