### PR TITLE
Specify parameter to remove warning

### DIFF
--- a/calvin_bringup/launch/imu.launch
+++ b/calvin_bringup/launch/imu.launch
@@ -23,6 +23,7 @@
     args="load imu_filter_madgwick/ImuFilterNodelet imu_manager" 
     output="screen">
 
+    <param name="use_magnetic_field_msg" value="true"/>
     <param name="use_mag" value="false"/>
     <param name="publish_tf" value="false" />
   </node>


### PR DESCRIPTION
mintar added a warning in 
https://github.com/ccny-ros-pkg/imu_tools/commit/2d70e4433b914bb871863469cae8d670d38776f8 
Although this parameter isn't relevant for calvin at the moment, let's specify
it to remove the warning on startup.
