### PR TITLE
strongly increase allowed_goal_duration_margin

### DIFF
--- a/calvin_moveit_config/launch/trajectory_execution.launch
+++ b/calvin_moveit_config/launch/trajectory_execution.launch
@@ -10,7 +10,7 @@
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
   <param name="allowed_execution_duration_scaling" value="1.5"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="1.5"/> <!-- default 0.5 -->
+  <param name="allowed_goal_duration_margin" value="5.0"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="calvin" />


### PR DESCRIPTION
The maximum execution time of a trajectory before aborting is computed as

> expected_trajectory_duration = expected_trajectory_duration *
> allowed_execution_duration_scaling_ +
> ros::Duration(allowed_goal_duration_margin_);

Increase the absolute offset to avoid errors due to slow communication between
moveit, katana's trajectory service and the actual katana arm.
