### PR TITLE
increase density of collision checking in ompl planner

### DIFF
--- a/calvin_moveit_config/config/ompl_planning.yaml
+++ b/calvin_moveit_config/config/ompl_planning.yaml
@@ -35,7 +35,7 @@ arm:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(katana_motor1_pan_joint,katana_motor2_lift_joint)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 gripper:
   planner_configs:
     - SBLkConfigDefault


### PR DESCRIPTION
Without the change
`roslaunch calvin_moveit_config demo.launch` and
`rosrun calvin_pick_n_place calvin_pick_n_place`
works fine over here.

With the patch the planner returns an invalid trajectory that makes the gripper collide
with the testbox.

@mintar please review and check
